### PR TITLE
Remove redundant symfony/polyfill-php73 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "phpcollection/phpcollection": "^0.6",
         "doctrine/annotations": "^1.13 || ^2.0",
         "doctrine/instantiator": "^1.4 || ^2.0",
-        "symfony/polyfill-php73": "^1.23",
         "doctrine/dbal": "^3.3.7"
     },
     "conflict": {


### PR DESCRIPTION
This package depends on `symfony/polyfill-php73`, but also `php: ^7.4|^8.0`, so the polyfill requirement doesn't seem necessary anymore?